### PR TITLE
Remove pkg-resources==0.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ netifaces==0.10.6
 pathlib2==2.3.0
 pexpect==4.4.0
 pickleshare==0.7.4
-pkg-resources==0.0.0
 prompt-toolkit==1.0.15
 ptyprocess==0.5.2
 Pygments==2.2.0


### PR DESCRIPTION
Causes error during install; seems to not be necessary.